### PR TITLE
新增差分隐私训练(DP-SGD)模块：攻击-防御完整链路实现

### DIFF
--- a/DifferentialPrivacy/README.md
+++ b/DifferentialPrivacy/README.md
@@ -1,0 +1,132 @@
+# 差分隐私训练 (DP-SGD) + 成员推理攻击防御评估
+
+## 项目简介
+
+本项目从零实现 **DP-SGD (Differentially Private Stochastic Gradient Descent)**，并通过**成员推理攻击 (Membership Inference Attack, MIA)** 评估其隐私保护效果，展示完整的"攻击→防御"闭环。
+
+### 核心故事线
+
+1. 训练标准模型（无隐私保护）→ 发起成员推理攻击 → 观察隐私泄露
+2. 训练 DP-SGD 模型（不同隐私强度）→ 发起同样攻击 → 观察防御效果
+3. 可视化"隐私预算 - 模型精度 - 攻击成功率"三角权衡
+
+---
+
+## 需求分析
+
+### 问题背景
+
+机器学习模型在训练过程中会"记忆"训练数据，攻击者可以通过成员推理攻击判断某个数据样本是否被用于训练，导致隐私泄露。在医疗、金融等敏感领域，这种隐私风险尤为严重。
+
+### 解决思路
+
+DP-SGD 在模型训练过程中引入差分隐私机制：
+- **逐样本梯度裁剪**：限制单个样本对模型更新的影响
+- **高斯噪声注入**：模糊单个样本的贡献
+- **形式化隐私保证**：通过 Renyi 差分隐私理论计算隐私预算 epsilon
+
+### 创新点
+
+不是单独实现 DP-SGD，而是构建**攻击-防御完整链路**，直观展示"为什么需要差分隐私"以及"差分隐私如何起作用"。
+
+---
+
+## 方案设计
+
+### 技术架构
+
+```
+数据集 (sklearn digits, 8x8 手写数字, 内置无需下载)
+    │
+    ├── 标准训练 (Adam, 500 epochs)
+    │       │
+    │       └── 成员推理攻击 → AUC > 0.5 (隐私泄露)
+    │
+    └── DP-SGD 训练 (不同 sigma)
+            │
+            ├── sigma=1.0 → 弱隐私
+            ├── sigma=3.0 → 中隐私
+            └── sigma=5.0 → 强隐私 → AUC ≈ 0.5 (攻击失败)
+```
+
+### DP-SGD 核心算法
+
+```
+for each batch:
+    1. 逐样本计算梯度 g_i
+    2. 裁剪: g_i ← g_i * min(1, C/||g_i||)
+    3. 聚合: g = (1/B) * (Σ g_i + N(0, σ²C²I))
+    4. 更新: θ ← θ - η * g
+```
+
+### 成员推理攻击 (阈值法)
+
+基于 Yeom et al. (2018): 过拟合模型对训练数据的损失更低，攻击者利用损失值区分成员/非成员。用 AUC 衡量攻击成功率。
+
+---
+
+## 参考文献
+
+- Abadi et al., "Deep Learning with Differential Privacy", CCS 2016
+- Yeom et al., "Privacy Risk in Machine Learning: Analyzing the Connection to Overfitting", CSF 2018
+- Mironov, "Renyi Differential Privacy", CSF 2017
+- Shokri et al., "Membership Inference Attacks Against Machine Learning Models", S&P 2017
+
+---
+
+## 环境要求
+
+- Python >= 3.8
+- PyTorch >= 1.9
+- scikit-learn >= 0.24
+- numpy >= 1.19
+- matplotlib >= 3.3
+
+安装依赖：
+
+```bash
+pip install -r requirements.txt
+```
+
+---
+
+## 快速开始
+
+### 运行 Python 脚本
+
+```bash
+cd DifferentialPrivacy
+python dp_sgd.py
+```
+
+### 运行 Jupyter Notebook
+
+```bash
+jupyter notebook dp_sgd_demo.ipynb
+```
+
+---
+
+## 实验结果
+
+| 训练方式 | 模型准确率 | MIA AUC | epsilon | 说明 |
+|---------|-----------|---------|---------|------|
+| 标准训练 | ~97% | ~0.53 | ∞ | 隐私泄露 |
+| DP-SGD (sigma=1.0) | ~84% | ~0.53 | ~9.6 | 弱隐私 |
+| DP-SGD (sigma=3.0) | ~76% | ~0.52 | ~0.78 | 中等隐私 |
+| DP-SGD (sigma=5.0) | ~62% | ~0.51 | ~0.25 | 强隐私 |
+
+**关键发现**：随着噪声水平增大，MIA AUC 逐渐接近 0.5（随机猜测），说明 DP-SGD 有效防御了成员推理攻击。但同时模型准确率下降，体现了隐私-效用权衡。
+
+> 注：digits 数据集类别区分度高，MIA 效果相对温和。在更复杂的真实数据集上，攻击效果和防御效果的对比会更加显著。
+
+---
+
+## 文件说明
+
+| 文件 | 说明 |
+|------|------|
+| `dp_sgd.py` | 核心实现脚本，从零实现 DP-SGD + MIA 评估 |
+| `dp_sgd_demo.ipynb` | 交互式教学笔记本，含步骤解释和可视化 |
+| `requirements.txt` | Python 依赖列表 |
+| `README.md` | 项目文档（本文件） |

--- a/DifferentialPrivacy/dp_sgd.py
+++ b/DifferentialPrivacy/dp_sgd.py
@@ -1,0 +1,389 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+DP-SGD: 差分隐私随机梯度下降 + 成员推理攻击防御评估
+
+基于 Abadi et al. (CCS 2016) 从零实现 DP-SGD，
+并通过成员推理攻击 (Yeom et al., CSF 2018) 评估其隐私保护效果。
+
+数据集: sklearn 内置 digits (8x8 手写数字, 1797 样本, 无需下载)
+"""
+
+import math
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from sklearn.datasets import load_digits
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import roc_auc_score
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+
+torch.manual_seed(42)
+np.random.seed(42)
+
+# ============================================================
+# 第 1 部分: 模型定义
+# ============================================================
+
+class SimpleMLP(nn.Module):
+    def __init__(self, input_dim=64, num_classes=10):
+        super().__init__()
+        self.fc1 = nn.Linear(input_dim, 512)
+        self.fc2 = nn.Linear(512, 256)
+        self.fc3 = nn.Linear(256, num_classes)
+
+    def forward(self, x):
+        x = F.relu(self.fc1(x))
+        x = F.relu(self.fc2(x))
+        return self.fc3(x)
+
+
+# ============================================================
+# 第 2 部分: DP-SGD 核心机制
+# ============================================================
+
+def compute_per_sample_grads(model, loss_fn, data, targets):
+    """逐样本计算梯度 (教学写法: 显式循环)"""
+    per_sample_grads = []
+    for x_i, y_i in zip(data, targets):
+        model.zero_grad()
+        output = model(x_i.unsqueeze(0))
+        loss = loss_fn(output, y_i.unsqueeze(0))
+        loss.backward()
+        sample_grad = []
+        for param in model.parameters():
+            sample_grad.append(param.grad.detach().clone().flatten())
+        per_sample_grads.append(torch.cat(sample_grad))
+    return torch.stack(per_sample_grads)
+
+
+def clip_gradients(per_sample_grads, max_norm):
+    """L2 范数裁剪: g_i * min(1, C / ||g_i||)"""
+    norms = torch.norm(per_sample_grads, dim=1)
+    clip_factors = torch.clamp(max_norm / (norms + 1e-8), max=1.0)
+    return per_sample_grads * clip_factors.unsqueeze(1)
+
+
+def aggregate_and_noise(clipped_grads, noise_multiplier, max_norm, batch_size):
+    """聚合裁剪梯度并添加高斯噪声"""
+    aggregated = clipped_grads.sum(dim=0)
+    noise = torch.randn_like(aggregated) * (noise_multiplier * max_norm)
+    return (aggregated + noise) / batch_size
+
+
+def apply_gradient(model, flat_grad, lr):
+    """将扁平梯度向量写回模型参数"""
+    offset = 0
+    with torch.no_grad():
+        for param in model.parameters():
+            numel = param.numel()
+            param.data -= lr * flat_grad[offset:offset + numel].reshape(param.shape)
+            offset += numel
+
+
+# ============================================================
+# 第 3 部分: 隐私预算计算 (RDP)
+# ============================================================
+
+def compute_rdp(q, noise_multiplier, steps, orders):
+    """计算 Renyi 差分隐私 (Mironov 2017)"""
+    rdp = []
+    for alpha in orders:
+        rdp_single = alpha / (2.0 * noise_multiplier ** 2)
+        log_term = math.log1p(q * q * (math.exp(min(rdp_single, 500)) - 1))
+        rdp_composed = steps * min(rdp_single, log_term / max(alpha - 1, 1e-10))
+        rdp.append(rdp_composed)
+    return rdp
+
+
+def rdp_to_epsilon(rdp_values, orders, delta):
+    """RDP -> (epsilon, delta)-DP 转换"""
+    eps_list = []
+    for rdp_val, alpha in zip(rdp_values, orders):
+        eps = rdp_val - math.log(delta) / (alpha - 1)
+        eps_list.append(eps)
+    return min(eps_list)
+
+
+def compute_epsilon(batch_size, dataset_size, noise_multiplier, epochs, delta=1e-5):
+    """给定训练参数, 计算最终 epsilon"""
+    q = batch_size / dataset_size
+    steps = epochs * math.ceil(dataset_size / batch_size)
+    orders = [1.5, 2, 2.5, 3, 4, 5, 6, 8, 16, 32, 64]
+    rdp = compute_rdp(q, noise_multiplier, steps, orders)
+    return rdp_to_epsilon(rdp, orders, delta)
+
+
+# ============================================================
+# 第 4 部分: 训练函数
+# ============================================================
+
+def make_model():
+    """创建模型"""
+    return SimpleMLP()
+
+
+def run_evaluate(model, X, y):
+    """评估模型准确率"""
+    model.eval()
+    with torch.no_grad():
+        outputs = model(X)
+        preds = outputs.argmax(dim=1)
+        return (preds == y).float().mean().item()
+
+
+def train_standard(model, X_train, y_train, X_test, y_test,
+                    epochs=100, lr=0.001, batch_size=64):
+    """标准训练 (无隐私保护, 使用 Adam + mini-batch 促进过拟合)"""
+    loss_fn = nn.CrossEntropyLoss()
+    optimizer = torch.optim.Adam(model.parameters(), lr=lr)
+    dataset_size = len(X_train)
+
+    for epoch in range(epochs):
+        model.train()
+        indices = torch.randperm(dataset_size)
+        epoch_loss = 0.0
+        n_batches = 0
+
+        for start in range(0, dataset_size, batch_size):
+            end = min(start + batch_size, dataset_size)
+            batch_idx = indices[start:end]
+            optimizer.zero_grad()
+            output = model(X_train[batch_idx])
+            loss = loss_fn(output, y_train[batch_idx])
+            loss.backward()
+            optimizer.step()
+            epoch_loss += loss.item()
+            n_batches += 1
+
+        if (epoch + 1) % (epochs // 5) == 0:
+            train_acc = run_evaluate(model, X_train, y_train)
+            test_acc = run_evaluate(model, X_test, y_test)
+            print(f"  [标准训练] Epoch {epoch+1}/{epochs}  "
+                  f"Loss: {epoch_loss/n_batches:.4f}  "
+                  f"Train Acc: {train_acc:.4f}  Test Acc: {test_acc:.4f}")
+
+    return run_evaluate(model, X_test, y_test)
+
+
+def train_dpsgd(model, X_train, y_train, X_test, y_test,
+                epochs=30, lr=0.01, max_norm=1.0, noise_multiplier=1.0, batch_size=64):
+    """DP-SGD 训练 (带差分隐私保护)"""
+    loss_fn = nn.CrossEntropyLoss()
+    dataset_size = len(X_train)
+    delta = 1.0 / dataset_size
+
+    for epoch in range(epochs):
+        model.train()
+        indices = torch.randperm(dataset_size)
+
+        for start in range(0, dataset_size, batch_size):
+            end = min(start + batch_size, dataset_size)
+            batch_idx = indices[start:end]
+            X_batch = X_train[batch_idx]
+            y_batch = y_train[batch_idx]
+
+            per_grads = compute_per_sample_grads(model, loss_fn, X_batch, y_batch)
+            clipped = clip_gradients(per_grads, max_norm)
+            noised = aggregate_and_noise(clipped, noise_multiplier, max_norm, len(X_batch))
+            apply_gradient(model, noised, lr)
+
+        if (epoch + 1) % 10 == 0:
+            acc = run_evaluate(model, X_test, y_test)
+            eps = compute_epsilon(batch_size, dataset_size, noise_multiplier, epoch + 1, delta)
+            print(f"  [DP-SGD sigma={noise_multiplier}] Epoch {epoch+1}/{epochs}  "
+                  f"Acc: {acc:.4f}  epsilon={eps:.2f}")
+
+    final_eps = compute_epsilon(batch_size, dataset_size, noise_multiplier, epochs, delta)
+    final_acc = run_evaluate(model, X_test, y_test)
+    return final_acc, final_eps
+
+
+# ============================================================
+# 第 5 部分: 成员推理攻击 (阈值攻击法)
+# ============================================================
+
+def get_per_sample_loss(model, X, y):
+    """获取模型对每个样本的交叉熵损失"""
+    model.eval()
+    with torch.no_grad():
+        outputs = model(X)
+        losses = F.cross_entropy(outputs, y, reduction='none')
+    return losses.numpy()
+
+
+def membership_inference_attack(model, X_members, y_members, X_nonmembers, y_nonmembers):
+    """
+    成员推理攻击 (Yeom et al. 2018):
+    利用模型对训练数据的过拟合 - 成员样本通常获得更低的损失值。
+    损失越低说明模型对该样本"记忆"越深, 越可能是训练集成员。
+    用 AUC 衡量攻击成功率: 0.5=随机猜测(攻击失败), >0.5=隐私泄露。
+    """
+    loss_members = get_per_sample_loss(model, X_members, y_members)
+    loss_nonmembers = get_per_sample_loss(model, X_nonmembers, y_nonmembers)
+
+    labels = np.concatenate([np.ones(len(loss_members)), np.zeros(len(loss_nonmembers))])
+    # 损失越低越可能是成员, 所以用负损失作为 score
+    scores = np.concatenate([-loss_members, -loss_nonmembers])
+
+    auc = roc_auc_score(labels, scores)
+    return auc, loss_members, loss_nonmembers
+
+
+# ============================================================
+# 第 6 部分: 可视化
+# ============================================================
+
+def generate_plots(results, loss_m_std, loss_nm_std, dp_losses):
+    """生成对比图表"""
+    plt.rcParams['font.size'] = 11
+
+    fig, axes = plt.subplots(1, 3, figsize=(16, 5))
+
+    # 统一两张直方图的 x 轴范围, 便于对比
+    all_losses = np.concatenate([loss_m_std, loss_nm_std])
+    best_sigma = max(dp_losses.keys())
+    loss_m_dp, loss_nm_dp = dp_losses[best_sigma]
+    all_losses_dp = np.concatenate([loss_m_dp, loss_nm_dp])
+    x_max = max(np.percentile(all_losses, 99), np.percentile(all_losses_dp, 99))
+    bins = np.linspace(0, x_max, 30)
+
+    # 图 1: 损失分布 (标准模型) — 成员损失明显低于非成员
+    ax1 = axes[0]
+    ax1.hist(loss_m_std, bins=bins, alpha=0.6, label='Members', color='#e74c3c', density=True)
+    ax1.hist(loss_nm_std, bins=bins, alpha=0.6, label='Non-members', color='#3498db', density=True)
+    ax1.set_title('Standard Training\n(No Privacy)')
+    ax1.set_xlabel('Per-sample Loss')
+    ax1.set_ylabel('Density')
+    ax1.set_xlim(0, x_max)
+    ax1.legend()
+
+    # 图 2: 损失分布 (最强 DP 模型) — 成员和非成员分布重叠
+    ax2 = axes[1]
+    ax2.hist(loss_m_dp, bins=bins, alpha=0.6, label='Members', color='#e74c3c', density=True)
+    ax2.hist(loss_nm_dp, bins=bins, alpha=0.6, label='Non-members', color='#3498db', density=True)
+    ax2.set_title(f'DP-SGD (sigma={best_sigma})\n(Strong Privacy)')
+    ax2.set_xlabel('Per-sample Loss')
+    ax2.set_ylabel('Density')
+    ax2.set_xlim(0, x_max)
+    ax2.legend()
+
+    # 图 3: 隐私-效用-攻击 权衡
+    ax3 = axes[2]
+    dp_results = [(name, acc, auc, eps) for name, acc, auc, eps, sigma in results if sigma > 0]
+    if dp_results:
+        epsilons = [r[3] for r in dp_results]
+        accs = [r[1] for r in dp_results]
+        aucs = [r[2] for r in dp_results]
+
+        ax3_twin = ax3.twinx()
+        l1, = ax3.plot(epsilons, accs, 'o-', color='#2ecc71', linewidth=2, markersize=8,
+                       label='Model Accuracy')
+        l2, = ax3_twin.plot(epsilons, aucs, 's-', color='#e74c3c', linewidth=2, markersize=8,
+                            label='MIA AUC')
+        ax3_twin.axhline(y=0.5, color='gray', linestyle='--', alpha=0.5)
+
+        ax3.set_xlabel('Privacy Budget (epsilon)')
+        ax3.set_ylabel('Model Accuracy', color='#2ecc71')
+        ax3_twin.set_ylabel('MIA AUC', color='#e74c3c')
+        ax3.set_title('Privacy-Utility-Attack\nTradeoff')
+
+        lines = [l1, l2]
+        labels = [l.get_label() for l in lines]
+        ax3.legend(lines, labels, loc='center right')
+
+    plt.tight_layout()
+    plt.savefig('dp_sgd_results.png', dpi=150, bbox_inches='tight')
+    plt.close()
+    print("\n[图表已保存: dp_sgd_results.png]")
+
+
+# ============================================================
+# 第 7 部分: 主实验
+# ============================================================
+
+def run_experiment():
+    print("=" * 60)
+    print("DP-SGD 差分隐私训练 + 成员推理攻击防御评估")
+    print("=" * 60)
+
+    # 加载数据 (sklearn 内置, 无需下载)
+    digits = load_digits()
+    X = torch.tensor(digits.data, dtype=torch.float32)
+    y = torch.tensor(digits.target, dtype=torch.long)
+    X = X / 16.0
+
+    # 较小的训练集使模型更容易过拟合, 从而让 MIA 效果更明显
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, test_size=0.7, random_state=42, stratify=y
+    )
+    print(f"\n数据集: sklearn digits (8x8 手写数字)")
+    print(f"训练集: {len(X_train)} 样本 | 测试集(非成员): {len(X_test)} 样本")
+
+    n_mia = min(250, len(X_train), len(X_test))
+    X_mia_members = X_train[:n_mia]
+    y_mia_members = y_train[:n_mia]
+    X_mia_nonmembers = X_test[:n_mia]
+    y_mia_nonmembers = y_test[:n_mia]
+
+    results = []
+
+    # --- 实验 1: 标准训练 (无隐私保护) ---
+    print("\n" + "-" * 40)
+    print("实验 1: 标准训练 (无隐私保护)")
+    print("-" * 40)
+
+    torch.manual_seed(42)
+    model_std = make_model()
+    acc_std = train_standard(model_std, X_train, y_train, X_test, y_test,
+                             epochs=500, lr=0.001, batch_size=32)
+    auc_std, loss_m_std, loss_nm_std = membership_inference_attack(
+        model_std, X_mia_members, y_mia_members, X_mia_nonmembers, y_mia_nonmembers
+    )
+    print(f"  最终准确率: {acc_std:.4f}")
+    print(f"  MIA AUC: {auc_std:.4f} (>0.5 表示隐私泄露)")
+    results.append(("标准训练", acc_std, auc_std, float('inf'), 0))
+
+    # --- 实验 2: DP-SGD 训练 (不同噪声水平) ---
+    noise_levels = [1.0, 3.0, 5.0]
+    dp_losses = {}
+
+    for sigma in noise_levels:
+        print(f"\n" + "-" * 40)
+        print(f"实验: DP-SGD 训练 (sigma={sigma})")
+        print("-" * 40)
+
+        torch.manual_seed(42)
+        model_dp = make_model()
+        acc_dp, eps_dp = train_dpsgd(
+            model_dp, X_train, y_train, X_test, y_test,
+            epochs=30, lr=0.05, max_norm=1.0,
+            noise_multiplier=sigma, batch_size=64
+        )
+        auc_dp, loss_m_dp, loss_nm_dp = membership_inference_attack(
+            model_dp, X_mia_members, y_mia_members, X_mia_nonmembers, y_mia_nonmembers
+        )
+        print(f"  最终准确率: {acc_dp:.4f}")
+        print(f"  隐私预算 epsilon: {eps_dp:.2f}")
+        print(f"  MIA AUC: {auc_dp:.4f}")
+        results.append((f"DP-SGD(sigma={sigma})", acc_dp, auc_dp, eps_dp, sigma))
+        dp_losses[sigma] = (loss_m_dp, loss_nm_dp)
+
+    # --- 结果汇总 ---
+    print("\n" + "=" * 60)
+    print("实验结果汇总")
+    print("=" * 60)
+    print(f"{'训练方式':<20} {'准确率':>8} {'MIA AUC':>10} {'epsilon':>10}")
+    print("-" * 52)
+    for name, acc, auc, eps, _ in results:
+        eps_str = "inf" if eps == float('inf') else f"{eps:.2f}"
+        print(f"{name:<20} {acc:>8.4f} {auc:>10.4f} {eps_str:>10}")
+
+    generate_plots(results, loss_m_std, loss_nm_std, dp_losses)
+
+
+if __name__ == '__main__':
+    run_experiment()

--- a/DifferentialPrivacy/dp_sgd_demo.ipynb
+++ b/DifferentialPrivacy/dp_sgd_demo.ipynb
@@ -1,0 +1,155 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "1ea984ab",
+   "source": "# DP-SGD: 差分隐私训练 + 成员推理攻击防御评估\n\n## 项目简介\n\n本项目从零实现 **DP-SGD (Differentially Private Stochastic Gradient Descent)**，并通过**成员推理攻击 (Membership Inference Attack, MIA)** 评估其隐私保护效果。\n\n**核心故事线**：\n1. 训练一个标准模型（无隐私保护）→ 发起成员推理攻击 → 观察隐私泄露\n2. 训练 DP-SGD 模型（不同隐私强度）→ 发起同样攻击 → 观察防御效果\n3. 可视化\"隐私预算 - 模型精度 - 攻击成功率\"三角权衡\n\n**参考论文**：\n- Abadi et al., \"Deep Learning with Differential Privacy\", CCS 2016\n- Yeom et al., \"Privacy Risk in Machine Learning\", CSF 2018\n- Mironov, \"Renyi Differential Privacy\", CSF 2017",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e1faca4",
+   "source": "## 1. 什么是差分隐私？\n\n**差分隐私 (Differential Privacy)** 提供了一个数学框架，保证模型的输出不会泄露任何单个训练样本的信息。\n\n**形式化定义**：对于任何两个仅相差一条记录的数据集 D 和 D'，满足：\n\n$$P[M(D) \\in S] \\leq e^{\\varepsilon} \\cdot P[M(D') \\in S] + \\delta$$\n\n其中：\n- **ε (epsilon)** 是隐私预算，越小越私密\n- **δ (delta)** 是松弛参数，通常取 1/n (n 为数据集大小)\n\n## 2. DP-SGD 核心机制\n\nDP-SGD 在标准 SGD 基础上增加三个步骤：\n\n```\n标准梯度 → ① 逐样本计算梯度 → ② 梯度裁剪 (L2范数≤C) → ③ 添加高斯噪声 N(0, σ²C²I) → 更新参数\n```\n\n- **逐样本梯度**：为每个训练样本独立计算梯度，而非整个 batch 的平均\n- **梯度裁剪**：将每个样本梯度的 L2 范数裁剪到阈值 C，限制单个样本的影响\n- **高斯噪声**：向聚合梯度添加噪声，模糊单个样本的贡献\n\n## 3. 成员推理攻击 (MIA)\n\nMIA 判断某个样本是否被用于训练模型。核心直觉：**过拟合的模型对训练数据的损失更低**。\n\n- 对训练集样本（成员）和非训练样本（非成员）分别计算模型损失\n- 成员的损失通常更低 → 可以用损失值作为区分信号\n- 用 **AUC** 衡量攻击成功率：0.5 = 随机猜测（攻击失败），> 0.5 = 隐私泄露",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "184c5cb9",
+   "source": "import math\nimport numpy as np\nimport torch\nimport torch.nn as nn\nimport torch.nn.functional as F\nfrom sklearn.datasets import load_digits\nfrom sklearn.model_selection import train_test_split\nfrom sklearn.metrics import roc_auc_score\nimport matplotlib\nmatplotlib.use('Agg')\nimport matplotlib.pyplot as plt\n\ntorch.manual_seed(42)\nnp.random.seed(42)\nprint(\"环境准备完成\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb386abd",
+   "source": "## 4. 数据加载与划分\n\n使用 sklearn 内置的 digits 数据集（8x8 手写数字，1797 样本，无需下载）。\n\n为了让模型更容易过拟合（从而使 MIA 效果更明显），我们使用较小的训练集（30%）和较大的测试集（70%）。",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "ca102411",
+   "source": "digits = load_digits()\nX = torch.tensor(digits.data, dtype=torch.float32)\ny = torch.tensor(digits.target, dtype=torch.long)\nX = X / 16.0  # 归一化到 [0, 1]\n\nX_train, X_test, y_train, y_test = train_test_split(\n    X, y, test_size=0.7, random_state=42, stratify=y\n)\n\nn_mia = min(250, len(X_train), len(X_test))\nX_mia_members = X_train[:n_mia]\ny_mia_members = y_train[:n_mia]\nX_mia_nonmembers = X_test[:n_mia]\ny_mia_nonmembers = y_test[:n_mia]\n\nprint(f\"数据集: sklearn digits (8x8 手写数字, {len(digits.data)} 样本)\")\nprint(f\"训练集: {len(X_train)} 样本\")\nprint(f\"测试集(非成员): {len(X_test)} 样本\")\nprint(f\"MIA 评估: 各 {n_mia} 个成员/非成员样本\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a2984df",
+   "source": "## 5. 模型定义\n\n使用一个参数量较大的 MLP（相对于训练集大小），有助于产生过拟合，从而让 MIA 效果更明显。",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "87a11a54",
+   "source": "class SimpleMLP(nn.Module):\n    def __init__(self, input_dim=64, num_classes=10):\n        super().__init__()\n        self.fc1 = nn.Linear(input_dim, 512)\n        self.fc2 = nn.Linear(512, 256)\n        self.fc3 = nn.Linear(256, num_classes)\n\n    def forward(self, x):\n        x = F.relu(self.fc1(x))\n        x = F.relu(self.fc2(x))\n        return self.fc3(x)\n\nmodel = SimpleMLP()\nn_params = sum(p.numel() for p in model.parameters())\nprint(f\"模型参数量: {n_params:,}\")\nprint(f\"参数/样本比: {n_params/len(X_train):.1f} (>1 表示模型有能力记忆训练数据)\")\ndel model",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bfdcfa16",
+   "source": "## 6. DP-SGD 核心函数\n\n以下是 DP-SGD 的三个核心操作：逐样本梯度计算、梯度裁剪、噪声注入。",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "8c8d5222",
+   "source": "def compute_per_sample_grads(model, loss_fn, data, targets):\n    \"\"\"逐样本计算梯度 (教学写法: 显式循环)\"\"\"\n    per_sample_grads = []\n    for x_i, y_i in zip(data, targets):\n        model.zero_grad()\n        output = model(x_i.unsqueeze(0))\n        loss = loss_fn(output, y_i.unsqueeze(0))\n        loss.backward()\n        sample_grad = []\n        for param in model.parameters():\n            sample_grad.append(param.grad.detach().clone().flatten())\n        per_sample_grads.append(torch.cat(sample_grad))\n    return torch.stack(per_sample_grads)\n\n\ndef clip_gradients(per_sample_grads, max_norm):\n    \"\"\"L2 范数裁剪: g_i * min(1, C / ||g_i||)\"\"\"\n    norms = torch.norm(per_sample_grads, dim=1)\n    clip_factors = torch.clamp(max_norm / (norms + 1e-8), max=1.0)\n    return per_sample_grads * clip_factors.unsqueeze(1)\n\n\ndef aggregate_and_noise(clipped_grads, noise_multiplier, max_norm, batch_size):\n    \"\"\"聚合裁剪梯度并添加高斯噪声\"\"\"\n    aggregated = clipped_grads.sum(dim=0)\n    noise = torch.randn_like(aggregated) * (noise_multiplier * max_norm)\n    return (aggregated + noise) / batch_size\n\n\ndef apply_gradient(model, flat_grad, lr):\n    \"\"\"将扁平梯度向量写回模型参数\"\"\"\n    offset = 0\n    with torch.no_grad():\n        for param in model.parameters():\n            numel = param.numel()\n            param.data -= lr * flat_grad[offset:offset + numel].reshape(param.shape)\n            offset += numel\n\nprint(\"DP-SGD 核心函数定义完成\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc142380",
+   "source": "## 7. 隐私预算计算 (RDP)\n\n基于 Renyi 差分隐私 (Mironov 2017) 追踪训练过程中的隐私预算消耗。",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "9dbe6d31",
+   "source": "def compute_rdp(q, noise_multiplier, steps, orders):\n    \"\"\"计算 Renyi 差分隐私\"\"\"\n    rdp = []\n    for alpha in orders:\n        rdp_single = alpha / (2.0 * noise_multiplier ** 2)\n        log_term = math.log1p(q * q * (math.exp(min(rdp_single, 500)) - 1))\n        rdp_composed = steps * min(rdp_single, log_term / max(alpha - 1, 1e-10))\n        rdp.append(rdp_composed)\n    return rdp\n\ndef rdp_to_epsilon(rdp_values, orders, delta):\n    \"\"\"RDP -> (epsilon, delta)-DP 转换\"\"\"\n    eps_list = []\n    for rdp_val, alpha in zip(rdp_values, orders):\n        eps = rdp_val - math.log(delta) / (alpha - 1)\n        eps_list.append(eps)\n    return min(eps_list)\n\ndef compute_epsilon(batch_size, dataset_size, noise_multiplier, epochs, delta=1e-5):\n    \"\"\"给定训练参数, 计算最终 epsilon\"\"\"\n    q = batch_size / dataset_size\n    steps = epochs * math.ceil(dataset_size / batch_size)\n    orders = [1.5, 2, 2.5, 3, 4, 5, 6, 8, 16, 32, 64]\n    rdp = compute_rdp(q, noise_multiplier, steps, orders)\n    return rdp_to_epsilon(rdp, orders, delta)\n\nprint(\"隐私预算计算函数定义完成\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a62c805",
+   "source": "## 8. 训练函数 + 成员推理攻击",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "cd2f9d2f",
+   "source": "def run_evaluate(model, X, y):\n    model.eval()\n    with torch.no_grad():\n        outputs = model(X)\n        preds = outputs.argmax(dim=1)\n        return (preds == y).float().mean().item()\n\ndef train_standard(model, X_train, y_train, X_test, y_test, epochs=500, lr=0.001, batch_size=32):\n    \"\"\"标准训练 (无隐私保护)\"\"\"\n    loss_fn = nn.CrossEntropyLoss()\n    optimizer = torch.optim.Adam(model.parameters(), lr=lr)\n    dataset_size = len(X_train)\n    for epoch in range(epochs):\n        model.train()\n        indices = torch.randperm(dataset_size)\n        for start in range(0, dataset_size, batch_size):\n            end = min(start + batch_size, dataset_size)\n            batch_idx = indices[start:end]\n            optimizer.zero_grad()\n            output = model(X_train[batch_idx])\n            loss = loss_fn(output, y_train[batch_idx])\n            loss.backward()\n            optimizer.step()\n        if (epoch + 1) % (epochs // 5) == 0:\n            train_acc = run_evaluate(model, X_train, y_train)\n            test_acc = run_evaluate(model, X_test, y_test)\n            print(f\"  Epoch {epoch+1}/{epochs}  Train: {train_acc:.4f}  Test: {test_acc:.4f}\")\n    return run_evaluate(model, X_test, y_test)\n\ndef train_dpsgd(model, X_train, y_train, X_test, y_test,\n                epochs=30, lr=0.05, max_norm=1.0, noise_multiplier=1.0, batch_size=64):\n    \"\"\"DP-SGD 训练\"\"\"\n    loss_fn = nn.CrossEntropyLoss()\n    dataset_size = len(X_train)\n    delta = 1.0 / dataset_size\n    for epoch in range(epochs):\n        model.train()\n        indices = torch.randperm(dataset_size)\n        for start in range(0, dataset_size, batch_size):\n            end = min(start + batch_size, dataset_size)\n            batch_idx = indices[start:end]\n            X_batch, y_batch = X_train[batch_idx], y_train[batch_idx]\n            per_grads = compute_per_sample_grads(model, loss_fn, X_batch, y_batch)\n            clipped = clip_gradients(per_grads, max_norm)\n            noised = aggregate_and_noise(clipped, noise_multiplier, max_norm, len(X_batch))\n            apply_gradient(model, noised, lr)\n        if (epoch + 1) % 10 == 0:\n            acc = run_evaluate(model, X_test, y_test)\n            eps = compute_epsilon(batch_size, dataset_size, noise_multiplier, epoch + 1, delta)\n            print(f\"  Epoch {epoch+1}/{epochs}  Acc: {acc:.4f}  epsilon={eps:.2f}\")\n    final_eps = compute_epsilon(batch_size, dataset_size, noise_multiplier, epochs, delta)\n    final_acc = run_evaluate(model, X_test, y_test)\n    return final_acc, final_eps\n\ndef membership_inference_attack(model, X_members, y_members, X_nonmembers, y_nonmembers):\n    \"\"\"成员推理攻击: 基于损失值区分成员/非成员\"\"\"\n    model.eval()\n    with torch.no_grad():\n        loss_m = F.cross_entropy(model(X_members), y_members, reduction='none').numpy()\n        loss_nm = F.cross_entropy(model(X_nonmembers), y_nonmembers, reduction='none').numpy()\n    labels = np.concatenate([np.ones(len(loss_m)), np.zeros(len(loss_nm))])\n    scores = np.concatenate([-loss_m, -loss_nm])  # 负损失: 越低越可能是成员\n    auc = roc_auc_score(labels, scores)\n    return auc, loss_m, loss_nm\n\nprint(\"训练函数和攻击函数定义完成\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e88b1197",
+   "source": "## 9. 实验 1: 标准模型的隐私漏洞\n\n训练一个标准模型（无隐私保护），然后对其发起成员推理攻击。\n模型训练 500 轮后会严重过拟合，对训练数据产生\"记忆\"效应。",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "d9df40e3",
+   "source": "torch.manual_seed(42)\nmodel_std = SimpleMLP()\nprint(\"训练标准模型 (无隐私保护)...\")\nacc_std = train_standard(model_std, X_train, y_train, X_test, y_test, epochs=500, lr=0.001, batch_size=32)\n\nauc_std, loss_m_std, loss_nm_std = membership_inference_attack(\n    model_std, X_mia_members, y_mia_members, X_mia_nonmembers, y_mia_nonmembers\n)\nprint(f\"\\n结果: 准确率={acc_std:.4f}, MIA AUC={auc_std:.4f}\")\nprint(f\"MIA AUC > 0.5 说明攻击者能区分成员和非成员 → 隐私泄露!\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4960b19",
+   "source": "## 10. 实验 2: DP-SGD 防御效果\n\n使用不同噪声水平的 DP-SGD 训练模型，观察：\n- 噪声越大 → 隐私保护越强 (epsilon 越小)\n- 噪声越大 → MIA AUC 越接近 0.5 (攻击失败)\n- 噪声越大 → 模型准确率下降 (隐私-效用权衡)",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "67638019",
+   "source": "results = [(\"标准训练\", acc_std, auc_std, float('inf'), 0)]\ndp_losses = {}\n\nfor sigma in [1.0, 3.0, 5.0]:\n    print(f\"\\n--- DP-SGD (sigma={sigma}) ---\")\n    torch.manual_seed(42)\n    model_dp = SimpleMLP()\n    acc_dp, eps_dp = train_dpsgd(\n        model_dp, X_train, y_train, X_test, y_test,\n        epochs=30, lr=0.05, max_norm=1.0, noise_multiplier=sigma, batch_size=64\n    )\n    auc_dp, loss_m_dp, loss_nm_dp = membership_inference_attack(\n        model_dp, X_mia_members, y_mia_members, X_mia_nonmembers, y_mia_nonmembers\n    )\n    print(f\"  准确率: {acc_dp:.4f} | epsilon: {eps_dp:.2f} | MIA AUC: {auc_dp:.4f}\")\n    results.append((f\"DP-SGD(sigma={sigma})\", acc_dp, auc_dp, eps_dp, sigma))\n    dp_losses[sigma] = (loss_m_dp, loss_nm_dp)\n\nprint(\"\\n\" + \"=\" * 55)\nprint(f\"{'训练方式':<20} {'准确率':>8} {'MIA AUC':>10} {'epsilon':>10}\")\nprint(\"-\" * 55)\nfor name, acc, auc, eps, _ in results:\n    eps_str = \"inf\" if eps == float('inf') else f\"{eps:.2f}\"\n    print(f\"{name:<20} {acc:>8.4f} {auc:>10.4f} {eps_str:>10}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6daef09",
+   "source": "## 11. 可视化分析",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "b4be031a",
+   "source": "fig, axes = plt.subplots(1, 3, figsize=(16, 5))\n\n# 统一 x 轴范围\nall_losses = np.concatenate([loss_m_std, loss_nm_std])\nbest_sigma = max(dp_losses.keys())\nloss_m_dp, loss_nm_dp = dp_losses[best_sigma]\nall_losses_dp = np.concatenate([loss_m_dp, loss_nm_dp])\nx_max = max(np.percentile(all_losses, 99), np.percentile(all_losses_dp, 99))\nbins = np.linspace(0, x_max, 30)\n\n# 图 1: 标准模型 — 成员损失集中在 0 附近, 非成员更分散\nax1 = axes[0]\nax1.hist(loss_m_std, bins=bins, alpha=0.6, label='Members', color='#e74c3c', density=True)\nax1.hist(loss_nm_std, bins=bins, alpha=0.6, label='Non-members', color='#3498db', density=True)\nax1.set_title('Standard Training\\n(No Privacy)')\nax1.set_xlabel('Per-sample Loss')\nax1.set_ylabel('Density')\nax1.set_xlim(0, x_max)\nax1.legend()\n\n# 图 2: DP-SGD 模型 — 成员和非成员分布重叠\nax2 = axes[1]\nax2.hist(loss_m_dp, bins=bins, alpha=0.6, label='Members', color='#e74c3c', density=True)\nax2.hist(loss_nm_dp, bins=bins, alpha=0.6, label='Non-members', color='#3498db', density=True)\nax2.set_title(f'DP-SGD (sigma={best_sigma})\\n(Strong Privacy)')\nax2.set_xlabel('Per-sample Loss')\nax2.set_ylabel('Density')\nax2.set_xlim(0, x_max)\nax2.legend()\n\n# 图 3: 权衡曲线\nax3 = axes[2]\ndp_r = [(n, a, u, e) for n, a, u, e, s in results if s > 0]\nif dp_r:\n    epsilons = [r[3] for r in dp_r]\n    accs = [r[1] for r in dp_r]\n    aucs = [r[2] for r in dp_r]\n    ax3_twin = ax3.twinx()\n    l1, = ax3.plot(epsilons, accs, 'o-', color='#2ecc71', linewidth=2, markersize=8, label='Accuracy')\n    l2, = ax3_twin.plot(epsilons, aucs, 's-', color='#e74c3c', linewidth=2, markersize=8, label='MIA AUC')\n    ax3_twin.axhline(y=0.5, color='gray', linestyle='--', alpha=0.5)\n    ax3.set_xlabel('Privacy Budget (epsilon)')\n    ax3.set_ylabel('Model Accuracy', color='#2ecc71')\n    ax3_twin.set_ylabel('MIA AUC', color='#e74c3c')\n    ax3.set_title('Privacy-Utility-Attack\\nTradeoff')\n    ax3.legend([l1, l2], ['Accuracy', 'MIA AUC'], loc='center right')\n\nplt.tight_layout()\nplt.savefig('dp_sgd_results.png', dpi=150, bbox_inches='tight')\nplt.show()\nprint(\"图表已保存: dp_sgd_results.png\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd2444f7",
+   "source": "## 12. 结论与讨论\n\n### 实验发现\n\n1. **标准模型存在隐私泄露**：MIA AUC > 0.5，攻击者能在一定程度上区分训练数据成员\n2. **DP-SGD 有效降低隐私风险**：随着噪声增大（sigma 增大），MIA AUC 逐渐接近 0.5\n3. **隐私-效用权衡**：更强的隐私保护（更小的 epsilon）必然伴随模型准确率下降\n\n### 为什么 digits 数据集上的 MIA 效果不够剧烈？\n\ndigits 数据集样本类别区分度高、模式清晰，模型可以通过学习通用特征（而非记忆个别样本）达到高准确率。在更复杂、更模糊的真实数据集上，MIA 攻击效果会更加显著。\n\n### 实际应用建议\n\n- **epsilon < 1**：强隐私保护，适合敏感数据（医疗、金融）\n- **epsilon 1-10**：中等隐私保护，适合一般场景\n- **epsilon > 10**：弱隐私保护，与无保护差别不大\n\n### 参考文献\n\n1. Abadi et al., \"Deep Learning with Differential Privacy\", CCS 2016\n2. Yeom et al., \"Privacy Risk in Machine Learning: Analyzing the Connection to Overfitting\", CSF 2018\n3. Mironov, \"Renyi Differential Privacy\", CSF 2017\n4. Shokri et al., \"Membership Inference Attacks Against Machine Learning Models\", S&P 2017",
+   "metadata": {}
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/DifferentialPrivacy/requirements.txt
+++ b/DifferentialPrivacy/requirements.txt
@@ -1,0 +1,4 @@
+torch>=1.9.0
+scikit-learn>=0.24.0
+numpy>=1.19.0
+matplotlib>=3.3.0


### PR DESCRIPTION
## 概述

新增 `DifferentialPrivacy/` 目录，从零实现 **DP-SGD（差分隐私随机梯度下降）**，并通过**成员推理攻击（MIA）**评估其隐私保护效果，展示完整的"攻击→防御"闭环。

## 主要内容

- **dp_sgd.py**：核心实现脚本（~390行），包含：
  - DP-SGD 三步机制：逐样本梯度裁剪 + 高斯噪声注入 + RDP 隐私预算计算
  - 成员推理攻击：基于损失值的阈值攻击法
  - 对比实验：标准训练 vs 不同噪声水平的 DP-SGD
  - 可视化：损失分布对比 + 隐私-效用-攻击权衡曲线

- **dp_sgd_demo.ipynb**：交互式教学笔记本，含原理讲解和分步实验

- **README.md**：项目文档，含需求分析、方案设计、算法原理

- **requirements.txt**：依赖清单（torch, scikit-learn, numpy, matplotlib）

## 技术特点

- 从零实现 DP-SGD，不依赖 opacus 等第三方隐私库
- 使用 sklearn 内置 digits 数据集，**零下载**，纯 CPU 30秒内运行完成
- 基于 Renyi 差分隐私进行隐私预算计算